### PR TITLE
alarm clock and priority_scheduling_1

### DIFF
--- a/devices/timer.c
+++ b/devices/timer.c
@@ -93,8 +93,16 @@ timer_sleep (int64_t ticks) {
 	int64_t start = timer_ticks ();
 
 	ASSERT (intr_get_level () == INTR_ON);
-	while (timer_elapsed (start) < ticks)
-		thread_yield ();
+
+	//==================================================================
+	//				Project 1 - Alarm Clock
+	//------------------------------------------------------------------
+	ThreadSleep(start + ticks); // 현재시간 + 잠들시간
+
+	// 기존의 코드는 thread_yield를 호출하면 잠들어야할 스레드가 바로 ready_list에 들어가게 된다. 
+	// while (timer_elapsed (start) < ticks)
+	// 	thread_yield ();
+	//==================================================================
 }
 
 /* Suspends execution for approximately MS milliseconds. */
@@ -126,6 +134,12 @@ static void
 timer_interrupt (struct intr_frame *args UNUSED) {
 	ticks++;
 	thread_tick ();
+
+	//==================================================================
+	//				Project 1 - Alarm Clock
+	//------------------------------------------------------------------
+	ThreadWakeUp(ticks); // 매 tick 마다 꺠울 스레드가 있는지를 확인하기 위해 호출 
+	//==================================================================
 }
 
 /* Returns true if LOOPS iterations waits for more than one timer

--- a/include/threads/synch.h
+++ b/include/threads/synch.h
@@ -3,6 +3,7 @@
 
 #include <list.h>
 #include <stdbool.h>
+#include <debug.h>
 
 /* A counting semaphore. */
 struct semaphore {
@@ -37,6 +38,12 @@ void cond_init (struct condition *);
 void cond_wait (struct condition *, struct lock *);
 void cond_signal (struct condition *, struct lock *);
 void cond_broadcast (struct condition *, struct lock *);
+
+//==================================================================
+//				Project 1 - Priority Scheduling
+//------------------------------------------------------------------
+bool CompareSemaphoreByPriority(const struct list_elem* l, const struct list_elem* r, void* aux UNUSED);
+//==================================================================
 
 /* Optimization barrier.
  *

--- a/include/threads/thread.h
+++ b/include/threads/thread.h
@@ -152,6 +152,7 @@ void do_iret (struct intr_frame *tf);
 //==================================================================
 //				Project 1 - Alarm Clock
 //------------------------------------------------------------------
+
 /* 잠들 스레드를 sleep_list에 삽입해준다.
 	이 때 ticks가 작은 스레드가 앞부분에 위치하도록 정렬하여 삽입한다. */
 void ThreadSleep(int64_t ticks);
@@ -161,12 +162,20 @@ bool CompareThreadByTicks(const struct list_elem* l, const struct list_elem* r, 
 
 // sleep_list를 확인해서 꺠어날 스레드들을 ready_list로 옮겨주는 함수 
 void ThreadWakeUp(int64_t current_ticks);
+
 //==================================================================
 
 
 //==================================================================
 //				Project 1 - Priority Scheduling
 //------------------------------------------------------------------
+
+// 우선순위를 기준으로 정렬할 때 사용하는 함수
 bool CompareThreadByPriority(const struct list_elem* l, const struct list_elem* r, void *aux UNUSED);
+
+// yield를 할 때 우선순위를 기준으로 양보하는 함수 
+void ThreadYieldByPriority();
+
 //==================================================================
+
 #endif /* threads/thread.h */

--- a/include/threads/thread.h
+++ b/include/threads/thread.h
@@ -92,6 +92,12 @@ struct thread {
 	char name[16];                      /* Name (for debugging purposes). */
 	int priority;                       /* Priority. */
 
+	//==================================================================
+	//				Project 1 - Alarm Clock
+	//------------------------------------------------------------------
+	int64_t wakeup_ticks;
+	//==================================================================
+
 	/* Shared between thread.c and synch.c. */
 	struct list_elem elem;              /* List element. */
 
@@ -143,4 +149,24 @@ int thread_get_load_avg (void);
 
 void do_iret (struct intr_frame *tf);
 
+//==================================================================
+//				Project 1 - Alarm Clock
+//------------------------------------------------------------------
+/* 잠들 스레드를 sleep_list에 삽입해준다.
+	이 때 ticks가 작은 스레드가 앞부분에 위치하도록 정렬하여 삽입한다. */
+void ThreadSleep(int64_t ticks);
+
+// ticks를 기준으로 정렬할 때 사용하는 함수
+bool CompareThreadByTicks(const struct list_elem* l, const struct list_elem* r, void *aux UNUSED);
+
+// sleep_list를 확인해서 꺠어날 스레드들을 ready_list로 옮겨주는 함수 
+void ThreadWakeUp(int64_t current_ticks);
+//==================================================================
+
+
+//==================================================================
+//				Project 1 - Priority Scheduling
+//------------------------------------------------------------------
+bool CompareThreadByPriority(const struct list_elem* l, const struct list_elem* r, void *aux UNUSED);
+//==================================================================
 #endif /* threads/thread.h */

--- a/threads/thread.c
+++ b/threads/thread.c
@@ -678,8 +678,7 @@ void ThreadWakeUp(int64_t current_ticks)
 		}
 		else // 깰 시간이 아니라면 
 		{
-			//iter_sleep_list = list_next(iter_sleep_list); // 다음 elem으로 
-			break;
+			iter_sleep_list = list_next(iter_sleep_list); // 다음 elem으로 
 		}
 	}
 	intr_set_level(old_level); // 비활성화 시킨 인터럽트를 원래대로 되돌림 


### PR DESCRIPTION
busy-wating 방식에서 sleep-wakeup 방식으로 수정 
우선순위 스케쥴링 구현중 

priority-fifo와 priority-change가 pass가 안되는 문제가 있었는데 
우선순위 기반으로 thread_yield()를 호출해주는 함수를 구현한뒤 
thread_set_priority 함수에서 새로 우선순위를 수정해준다음 위 함수를 호출하는 식으로 해결 